### PR TITLE
Typo in URL for Team Statsheets

### DIFF
--- a/team-statsheet.md
+++ b/team-statsheet.md
@@ -6,7 +6,7 @@ Keep in mind that a team statsheet is associated with a particular game, so the 
 
 ## Endpoint
 
-`https://www.blaseball.com/database/teamsStatsheets?ids=:id1,:id2,...`
+`https://www.blaseball.com/database/teamStatsheets?ids=:id1,:id2,...`
 
 ## Response
 


### PR DESCRIPTION
was: https://www.blaseball.com/database/teamsStatsheets?ids=:id1,:id2,...
is: https://www.blaseball.com/database/teamStatsheets?ids=:id1,:id2,...